### PR TITLE
Minimal patch for misleading results at new targeted gas limit

### DIFF
--- a/scripts/create_page.ipynb
+++ b/scripts/create_page.ipynb
@@ -86,6 +86,8 @@
     "    curr_value = int(i[\"execution_payload_gas_limit\"])\n",
     "    if curr_value > last_value and (last_value-curr_value) <= last_value/(1/1024):\n",
     "        df.loc[ix, \"execution_payload_gas_limit_adj\"] = 60_000_000\n",
+    "    elif curr_value >= 36_000_000:\n",
+    "        df.loc[ix, \"execution_payload_gas_limit_adj\"] = 60_000_000\n",
     "    elif curr_value > last_value and (last_value-curr_value) > last_value/(1/1024):\n",
     "        print(\"something strange with slot \", int(i[\"slot\"]))\n",
     "    else:\n",


### PR DESCRIPTION
The data in the dashboard appears stalled at 50% because the original methodology relies on deltas in the gas limit and proposers at the new target aren't increasing the gas limit.

I think the entire methodology needs an overhaul, but this is the minimal patch to fix the data today.

Original methodology:
<img width="1152" alt="Screenshot 2025-02-09 at 2 45 00 PM" src="https://github.com/user-attachments/assets/7767025d-d0e6-4317-a7f4-aa686ecb31e0" />

Patch methodology:
<img width="1156" alt="Screenshot 2025-02-09 at 2 45 14 PM" src="https://github.com/user-attachments/assets/2ffc53e8-20a4-41c8-9a7c-9aac1183cb84" />
